### PR TITLE
Add missing instructions to make the podman launcher binary executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ work.
 
 ## Installation
 
-Download the binary and put it in your $PATH
+Download the binary, make it executable and put it in your $PATH
 
 Optionally, you can name it `podman` in order to make it easier to type/use
 


### PR DESCRIPTION
Hi,

This PR aims to add the instruction to make the podman launcher binary executable, which was missing from the documentation.
Related to: https://github.com/89luca89/distrobox/pull/970